### PR TITLE
create_trade_model

### DIFF
--- a/app/models/trade.rb
+++ b/app/models/trade.rb
@@ -1,0 +1,5 @@
+class Trade < ApplicationRecord
+  has_many :comments
+  belongs_to :item
+  belongs_to :user
+end

--- a/db/migrate/20190120103303_create_trades.rb
+++ b/db/migrate/20190120103303_create_trades.rb
@@ -1,0 +1,12 @@
+class CreateTrades < ActiveRecord::Migration[5.0]
+  def change
+    create_table :trades do |t|
+      t.string :deposit
+      t.integer :shipping_notification
+      t.references :item,    foreign_key: true
+      t.references :user,    foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190120102746) do
+ActiveRecord::Schema.define(version: 20190120103303) do
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "number",                null: false
@@ -68,6 +68,17 @@ ActiveRecord::Schema.define(version: 20190120102746) do
     t.index ["user_id"], name: "index_likes_on_user_id", using: :btree
   end
 
+  create_table "trades", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "deposit"
+    t.integer  "shipping_notification"
+    t.integer  "item_id"
+    t.integer  "user_id"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
+    t.index ["item_id"], name: "index_trades_on_item_id", using: :btree
+    t.index ["user_id"], name: "index_trades_on_user_id", using: :btree
+  end
+
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "nickname",                            null: false
     t.string   "email",                  default: "", null: false
@@ -97,4 +108,6 @@ ActiveRecord::Schema.define(version: 20190120102746) do
   add_foreign_key "items", "users"
   add_foreign_key "likes", "items"
   add_foreign_key "likes", "users"
+  add_foreign_key "trades", "items"
+  add_foreign_key "trades", "users"
 end


### PR DESCRIPTION
## WHAT
Rails g model trade
アソシエーションの記述追加

## WHY
取引中情報を管理する為。